### PR TITLE
@ Add start-button loading state and center the stop-debate CTA

### DIFF
--- a/docs/IMPLEMENTATION_NOTE.md
+++ b/docs/IMPLEMENTATION_NOTE.md
@@ -6,6 +6,30 @@
 
 ---
 
+## #4 — 시작 버튼 로딩 인디케이터 + 토론 종료 버튼 정렬 (D UI·UX)
+
+**배경**: 진행 중 발견된 두 가지 UI·UX 개선.
+1. 설정 화면의 `토론 시작` 버튼은 클릭 시 `startGame()`이 `POST /api/get-topic`(LLM 주제 생성)을 호출하지만, 응답 전까지 **시각적 대기 단서가 없고 버튼이 계속 활성** 상태였습니다. 주제 생성은 수 초가 걸릴 수 있어 사용자가 버튼을 수십 번 연타할 여지가 있었습니다.
+2. 진행 화면(`GameScreen`)의 `토론 그만두기` 버튼이 좌측 정렬(`SetupScreen`과 공유하는 좌측 flex 행 `.setup-cta`)이고 버튼 아래 여백이 없었습니다.
+
+**변경 내용**:
+- **로딩 인디케이터** (`frontend/src/`)
+  - `hooks/useGame.js`: `isStarting` 상태 추가. `startGame`은 `if (isStarting) return;`으로 재진입(연타)을 차단하고, `clearGame()` 후 `setIsStarting(true)`, `finally`에서 `setIsStarting(false)`로 성공·오류 양쪽에서 항상 해제. 반환 객체에 `isStarting` 노출.
+  - `App.js`: `SetupScreen`에 `isStarting={game.isStarting}` 전달.
+  - `components/SetupScreen.js`: `토론 시작` 버튼에 `disabled={isStarting}` + 로딩 중 스피너(`.btn-spinner`)와 `토론 준비 중…` 라벨 표시. `뒤로` 버튼도 로딩 중 비활성.
+  - `index.css`: `.btn:disabled`(hover `translateY` 리셋 포함), `.btn-loading`, `.btn-spinner`, `@keyframes btn-spin`, `prefers-reduced-motion` 정지 규칙 추가. 스피너 색은 골드 `btn-primary` 배경에 맞춤.
+- **종료 버튼 정렬** (`frontend/src/`)
+  - `components/GameScreen.js`: 래퍼 클래스를 `setup-cta setup-cta--center`로 변경.
+  - `index.css`: `.setup-cta--center { justify-content: center; margin-bottom: 34px; }` 추가. 공유 `.setup-cta` 규칙은 건드리지 않아 `SetupScreen`은 영향 없음(modifier로만 스코프).
+
+**검증**:
+- 구현 후 별도 검증 단계에서 5개 파일을 재확인: `isStarting` 상태/가드/`finally` 정상, JSX·중괄호 균형, 중복 선언 없음, 기존 CSS 규칙 보존, `.setup-cta--center`가 `GameScreen`에만 적용됨. 이슈 0건.
+- `clearGame()`은 `isStarting`을 건드리지 않으므로 `finally`가 플래그를 단독 소유 — stuck-true 위험 없음.
+
+**관련 로드맵**: README D "로딩 피드백 추가"의 시작 단계 부분에 해당. 진행 화면 턴 로딩은 이미 `.thinking`(리디자인 #2)으로 처리됨.
+
+---
+
 ## #3 — 시크릿 하드코딩 제거 및 `.env` 관리 (보안 강화)
 
 **배경**: `#2` 리팩토링에서 `SECRET_KEY`를 환경변수로 읽도록 바꿨지만, 소스(`settings.py`)에 **개발용 fallback 시크릿 문자열이 그대로 남아** 있었습니다. 이 값은 git 히스토리에도 포함되어 사실상 노출된 상태였습니다.

--- a/docs/design/DESIGN_SYSTEM.md
+++ b/docs/design/DESIGN_SYSTEM.md
@@ -119,6 +119,7 @@ ArguMind는 단순한 채팅이 아니라 **변증(辯證) — 두 입장의 충
   .seam               시그니처 단층선 (빈 div; ::after가 골드 결절점)
   .chip-affirm/-negate  .dot + 텍스트 (입장 칩)
   .btn / .btn-primary(골드) / .btn-ghost / .btn-submit(시안)
+  .btn:disabled(반투명·비활성, hover 이동 리셋) / .btn-loading(스피너+라벨 래퍼) > .btn-spinner(회전, reduced-motion 정지)
 
 레일(rail)            .rail > .combatant(.right){ .who,.role + .avatar-affirm } | .rail-mid{ .rail-turn,.rail-topic } | .combatant{ .avatar-negate + .who,.role }
 히어로(hero)          .hero > .eyebrow, h1.hero-title(.affirm/.negate span), .hero-sub, .hero-cta(.btn-primary,.btn-ghost,.hero-note)
@@ -132,7 +133,7 @@ ArguMind는 단순한 채팅이 아니라 **변증(辯證) — 두 입장의 충
 
 — 신규 제안 (§8) —
 설정(setup)          .setup > .eyebrow, h2, .setup-section(p.sec-label(span.no) , .opt-grid[.cols-2](button.opt-card[.is-selected][aria-pressed]( .ot,.od | .persona(.avatar-negate + div(.ot,.od)) )) | .seg(button[.is-selected][aria-pressed])) , p.setup-note(.chip-*) , .setup-cta(.btn-*)
-진행 추가            .rail-mid > .turn-pips(.pip[.done/.now]) ; .arg > … .judge-note(.jl + 텍스트) ; form.composer > … .composer-meta(.count>b , .hint)
+진행 추가            .rail-mid > .turn-pips(.pip[.done/.now]) ; .arg > … .judge-note(.jl + 텍스트) ; form.composer > … .composer-meta(.count>b , .hint) ; .setup-cta.setup-cta--center(중앙 정렬 + 하단 여백, 토론 그만두기 CTA)
 기록(history)        .history > .history-head( div(h2,p.hsub) , .record(.r(.rn[.win/.lose],.rl)) ) , .match-list( button.match-card[aria-label]( .badge.win/.lose , .match-topic(.mt,.mmeta(.chip-*)) , .match-right(.ms>b,.md) ) )
 ```
 
@@ -146,7 +147,7 @@ ArguMind는 단순한 채팅이 아니라 **변증(辯證) — 두 입장의 충
 
 - **반응형**: 모바일(≤760px)에서 `.arena`/`.verdict`/`.loop`는 1열로 쌓이고 `.seam`은 숨김, `.composer`는 세로 정렬.
 - **접근성**: 실제 `<button>`/`<textarea>`+`<label>`, `:focus-visible` 골드 아웃라인, 로딩 `aria-live`, 오류 `role="alert"`, 레이더 `aria-label`.
-- **모션**: `.thinking` 점 애니메이션은 `prefers-reduced-motion: reduce`에서 정지.
+- **모션**: `.thinking` 점 애니메이션과 `.btn-spinner` 회전은 `prefers-reduced-motion: reduce`에서 정지.
 - **CSS 규약**: 단일 클래스 선택자 위주 — 엘리먼트 선택자와 클래스 선택자가 간격(padding/margin)에서 충돌하지 않도록.
 
 ---

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -29,6 +29,7 @@ function App() {
           onMaxTurns={game.setMaxTurns}
           onStart={game.startGame}
           onBack={game.goToStart}
+          isStarting={game.isStarting}
         />
       )}
 

--- a/frontend/src/components/GameScreen.js
+++ b/frontend/src/components/GameScreen.js
@@ -196,7 +196,7 @@ export default function GameScreen({
         </div>
       </form>
 
-      <div className="setup-cta">
+      <div className="setup-cta setup-cta--center">
         <button className="btn btn-ghost" type="button" onClick={onRestart}>
           토론 그만두기
         </button>

--- a/frontend/src/components/SetupScreen.js
+++ b/frontend/src/components/SetupScreen.js
@@ -18,6 +18,7 @@ export default function SetupScreen({
   onMaxTurns,
   onStart,
   onBack,
+  isStarting,
 }) {
   return (
     <div className="setup">
@@ -110,10 +111,17 @@ export default function SetupScreen({
       </p>
 
       <div className="setup-cta">
-        <button className="btn btn-primary" type="button" onClick={onStart}>
-          토론 시작
+        <button className="btn btn-primary" type="button" onClick={onStart} disabled={isStarting}>
+          {isStarting ? (
+            <span className="btn-loading">
+              <span className="btn-spinner" aria-hidden="true"></span>
+              토론 준비 중…
+            </span>
+          ) : (
+            "토론 시작"
+          )}
         </button>
-        <button className="btn btn-ghost" type="button" onClick={onBack}>
+        <button className="btn btn-ghost" type="button" onClick={onBack} disabled={isStarting}>
           뒤로
         </button>
       </div>

--- a/frontend/src/hooks/useGame.js
+++ b/frontend/src/hooks/useGame.js
@@ -76,6 +76,7 @@ export default function useGame() {
 
   const [userInput, setUserInput] = useState("");
   const [isWaitingResponse, setIsWaitingResponse] = useState(false);
+  const [isStarting, setIsStarting] = useState(false);
   const [error, setError] = useState("");
 
   // Verdict + history list.
@@ -109,7 +110,9 @@ export default function useGame() {
   };
 
   const startGame = async () => {
+    if (isStarting) return;
     clearGame();
+    setIsStarting(true);
     try {
       const data = await getTopic({
         category,
@@ -125,6 +128,8 @@ export default function useGame() {
     } catch (err) {
       setError(`주제를 불러오지 못했습니다: ${err.message}`);
       setScreen(SCREENS.SETUP);
+    } finally {
+      setIsStarting(false);
     }
   };
 
@@ -256,6 +261,7 @@ export default function useGame() {
     userInput,
     setUserInput,
     isWaitingResponse,
+    isStarting,
     error,
     // verdict + history
     result,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -313,6 +313,7 @@ body {
 .seg button.is-selected { background: var(--verdict); color: #20190A; font-weight: 600; }
 .setup-note { font-family: var(--font-mono); font-size: .78rem; color: var(--muted-2); margin: 10px 0 0; }
 .setup-cta { margin-top: 34px; display: flex; gap: 14px; align-items: center; flex-wrap: wrap; }
+.setup-cta--center { justify-content: center; margin-bottom: 34px; }
 
 /* ---------- turn progress pips (rail) ---------- */
 .turn-pips { display: inline-flex; gap: 6px; justify-content: center; margin-top: 8px; }
@@ -331,6 +332,13 @@ body {
 .composer-meta .count b { color: var(--muted); font-weight: 600; }
 .composer-meta .hint { font-family: var(--font-mono); font-size: .72rem; color: var(--muted-2); }
 .btn-submit:disabled { opacity: .4; cursor: not-allowed; }
+.btn:disabled { opacity: .55; cursor: not-allowed; transform: none; }
+.btn-loading { display: inline-flex; align-items: center; gap: 8px; }
+.btn-spinner { width: 14px; height: 14px; border-radius: 50%;
+  border: 2px solid rgba(32,25,10,0.25); border-top-color: #20190A;
+  animation: btn-spin .7s linear infinite; }
+@keyframes btn-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce){ .btn-spinner { animation: none; } }
 
 /* ---------- verdict: judge summary (총평) ---------- */
 .summary { margin-top: 22px; padding-top: 16px; border-top: 1px solid var(--paper-2); }


### PR DESCRIPTION
## 무엇을 / 왜

진행 중 발견된 두 가지 UI·UX 개선입니다.

### 1. `토론 시작` 버튼 로딩 인디케이터
- 설정 화면의 `토론 시작` 버튼은 `startGame()` → `POST /api/get-topic`(LLM 주제 생성)을 호출하지만, 응답 전까지 **대기 단서가 없고 버튼이 계속 활성** 상태였습니다. 주제 생성은 수 초가 걸려 사용자가 버튼을 **수십 번 연타**할 여지가 있었습니다.
- `useGame`에 `isStarting` 상태 추가 — `if (isStarting) return;`로 재진입(연타) 차단, `finally`에서 항상 해제(성공·오류 모두).
- `App` → `SetupScreen`으로 전달, 로딩 중 두 버튼(`토론 시작`/`뒤로`) 비활성 + 스피너 & `토론 준비 중…` 라벨 표시.
- `.btn:disabled` / `.btn-loading` / `.btn-spinner` + `btn-spin` keyframe (`prefers-reduced-motion`에서 정지).

### 2. `토론 그만두기` 버튼 정렬
- 진행 화면 버튼이 공유 좌측 정렬 `.setup-cta` 행을 써서 좌측 정렬 + 하단 여백 없음.
- `.setup-cta--center` modifier(`justify-content: center; margin-bottom: 34px`) 추가, **`GameScreen`에만** 적용 — 공유 `.setup-cta`(및 `SetupScreen`)는 무영향.

## 문서
- `IMPLEMENTATION_NOTE.md` #4 — 변경 내용 + 검증 기록
- `DESIGN_SYSTEM.md` — atoms / 진행 마크업 계약 / 모션 기준 갱신

## 검증
구현 후 별도 검증 단계에서 5개 소스 파일 재확인: `isStarting` 가드/`finally` 정상, JSX·중괄호 균형, 중복 선언 없음, 기존 CSS 규칙 보존, `.setup-cta--center` 스코프 정확. 이슈 0건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)